### PR TITLE
Add Twitter Auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'sass-rails', '~> 5.0'
 gem 'basscss-rails'
 
 gem 'devise'
+gem 'omniauth'
+gem 'omniauth-twitter'
 
 gem 'slim-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (4.1.0)
     httparty (0.18.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -104,6 +105,16 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
+    oauth (0.5.4)
+    omniauth (1.9.1)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth (1.1.0)
+      oauth
+      omniauth (~> 1.0)
+    omniauth-twitter (1.4.0)
+      omniauth-oauth (~> 1.1)
+      rack
     orm_adapter (0.5.0)
     parallel (1.19.1)
     parser (2.7.0.4)
@@ -248,6 +259,8 @@ DEPENDENCIES
   loofah (~> 2.3.1)
   newrelic_rpm
   nokogiri (~> 1.10.8)
+  omniauth
+  omniauth-twitter
   pg (~> 0.18)
   pry
   pry-byebug

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default:
 	print 'type make deploy; make compile; make migrate_heroku; make reset_pk;'
 
 run:
-	TWITTER_API_PUBLIC="46927552-fhkefpaselwO17EDX2MeEcTkfC0CAzJ9In6fmi73H" TWITTER_API_SECRET="za7mEvzJuKlyFKFkYtRB1LS5KvCGGD3SaOULbj2tkxC51" bundle exec rails s
+	bundle exec rails s
 
 deploy:
 	git push heroku master

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default:
 	print 'type make deploy; make compile; make migrate_heroku; make reset_pk;'
 
 run:
-	bundle exec rails s
+	TWITTER_API_PUBLIC="46927552-fhkefpaselwO17EDX2MeEcTkfC0CAzJ9In6fmi73H" TWITTER_API_SECRET="za7mEvzJuKlyFKFkYtRB1LS5KvCGGD3SaOULbj2tkxC51" bundle exec rails s
 
 deploy:
 	git push heroku master

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -119,3 +119,8 @@ h1, h2 {
 .form-signup{
   max-width: 600px !important;
 }
+
+.auto-margins {
+  margin-top: auto;
+  margin-bottom: auto;
+}

--- a/app/controllers/privacy_controller.rb
+++ b/app/controllers/privacy_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PrivacyController < ApplicationController
+    def index
+    end
+  end
+  

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,30 +1,22 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # You should configure your model like this:
-  # devise :omniauthable, omniauth_providers: [:twitter]
+  def twitter
+    # You need to implement the method below in your model (e.g. app/models/user.rb)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
 
-  # You should also create an action method in this controller like this:
-  # def twitter
-  # end
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
+      set_flash_message(:notice, :success, kind: "Twitter") if is_navigational_format?
+    else
+      session["devise.twitter_data"] = request.env["omniauth.auth"].except("extra")
+      redirect_to new_user_registration_url
+    end
+  end
 
-  # More info at:
-  # https://github.com/plataformatec/devise#omniauth
+  def failure
+    redirect_to root_path
+  end
 
-  # GET|POST /resource/auth/twitter
-  # def passthru
-  #   super
-  # end
-
-  # GET|POST /users/auth/twitter/callback
-  # def failure
-  #   super
-  # end
-
-  # protected
-
-  # The path used when OmniAuth fails
-  # def after_omniauth_failure_path_for(scope)
-  #   super(scope)
-  # end
 end
+

--- a/app/views/privacy/index.html.slim
+++ b/app/views/privacy/index.html.slim
@@ -1,0 +1,7 @@
+.container
+  .row
+    .col-md-12
+        .h2
+          We respect your privacy
+        .h4
+          We like really do and stuff.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -20,6 +20,9 @@ Devise.setup do |config|
   # Configure the class responsible to send e-mails.
   config.mailer = 'Devise::Mailer'
 
+  # Twitter creds
+  config.omniauth :twitter, ENV['TWITTER_API_PUBLIC'], ENV['TWITTER_API_SECRET']
+
   # Configure the parent class responsible to send e-mails.
   config.parent_mailer = 'ActionMailer::Base'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users, controllers: { registrations: 'registrations' }
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks', registrations: 'registrations' }
   get 'sessions/new'
 
   root 'home#index'
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   get 'email_calendar/:id', to: 'email_calendar#email_to', as: :email_to
   post 'email_calendar', to: 'email_calendar#email_all', as: :email_all
   get 'email_calendar', to: 'email_calendar#index', as: :email_calendar
+
+  get 'privacy', to: 'privacy#index'
 
   resources :users, only: %i[index update show]
   resources :events

--- a/db/migrate/20200808183009_add_omniauth_to_users.rb
+++ b/db/migrate/20200808183009_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190524214030) do
+ActiveRecord::Schema.define(version: 20200808183009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,8 @@ ActiveRecord::Schema.define(version: 20190524214030) do
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
+    t.string   "provider"
+    t.string   "uid"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
Adds twitter authentication.

This requires two env variables TWITTER_API_PUBLIC and TWITTER_API_SECRET. The are from the consumer api keys on an app made at https://developer.twitter.com/ The app does require permissions to get user emails. And this permission requires a privacy page. I have added that. I assume Geekly has some generic copy for this somewhere that I will work on getting to update this. 

That app will need the policy page set and the following Callback URLs
http://127.0.0.1:3000/users/auth/twitter/callback
http://127.0.0.1:3000/auth/twitter/callback
http://127.0.0.1:3000/users/auth/twitter
http://127.0.0.1:3000/auth/twitter
of course these should be modified with the actual url of the deployed app, but these can also be added to allow for local dev.


if you haven't used them, Heroku env vars can be created following this https://devcenter.heroku.com/articles/config-vars